### PR TITLE
fixed bare variables

### DIFF
--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -18,7 +18,7 @@
     track_submodules: "{{ item.track_submodules | default(omit) }}"
     update: "{{ item.pull if item.pull is defined else (git_pull if git_pull else omit) }}"
     version: "{{ item.version | default(omit) }}"
-  with_items: git_repositories
+  with_items: "{{ git_repositories }}"
 
 - name: Setting mode on repositories
   file:
@@ -27,5 +27,5 @@
     owner: "{{ item.owner if item.owner is defined else (git_owner if git_owner else omit) }}"
     group: "{{ item.group if item.group is defined else (git_group if git_group else omit) }}"
     recurse: true
-  with_items: git_repositories
+  with_items: "{{ git_repositories }}"
   when: git_repositories


### PR DESCRIPTION
Bare varables were deprecated in Ansible 2.0.

https://docs.ansible.com/ansible/porting_guide_2.0.html

[DEPRECATION WARNING]: Using bare variables is deprecated. Update your
playbooks so that the environment value uses the full variable syntax
('{{git_repositories}}').
This feature will be removed in a future release.
Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
